### PR TITLE
Changed project to package reference and fixed potential NRE

### DIFF
--- a/src/realtime-session-with-stacks/Program.cs
+++ b/src/realtime-session-with-stacks/Program.cs
@@ -118,10 +118,11 @@ namespace realtime_session_with_stacks
                 // You can do this synchronously by just removing the call to ResolveSymbolsForModule from the Task and calling synchronously.
                 if(string.IsNullOrEmpty(current.CodeAddress.FullMethodName) && !ResolvedSymbolsForModule(current.CodeAddress.ModuleFile))
                 {
-                    Task.Factory.StartNew(() =>
+                    Task.Factory.StartNew((o) =>
                     {
-                        ResolveSymbolsForModule(current.CodeAddress.CodeAddresses, current.CodeAddress.ModuleFile);
-                    });
+                        var localCurrent = (TraceCallStack)o;
+                        ResolveSymbolsForModule(localCurrent.CodeAddress.CodeAddresses, localCurrent.CodeAddress.ModuleFile);
+                    }, current);
                 }
 
                 Console.WriteLine($"[0x{current.CodeAddress.Address:X}] {current.CodeAddress.ModuleName}!{current.CodeAddress.FullMethodName}");

--- a/src/realtime-session-with-stacks/realtime-session-with-stacks.csproj
+++ b/src/realtime-session-with-stacks/realtime-session-with-stacks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="C:\src\perfview\src\TraceEvent\TraceEvent.csproj" />
+    		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.4" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
 Hi Brian,

This is related to [issue 4](https://github.com/brianrob/examples/issues/4). I sometimes got an NRE when running in an environment with lots of symbols. 

Also uses a package reference to you can run after cloning this repo without the need for the eventtrace repo.   

Best regards,
Bart Vries